### PR TITLE
Update docs for component listing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Unity MCP acts as a bridge, allowing AI assistants (like Claude, Cursor) to inte
   *   `manage_editor`: Controls and queries the editor's state and settings.
   *   `manage_scene`: Manages scenes (load, save, create, get hierarchy, etc.).
   *   `manage_asset`: Performs asset operations (import, create, modify, delete, etc.).
-  *   `manage_gameobject`: Manages GameObjects: create, modify, delete, find, and component operations.
+  *   `manage_gameobject`: Manages GameObjects: create, modify, delete, find, and component operations. When retrieving objects you can optionally include component info using `include_components` or `include_component_properties`.
   *   `execute_menu_item`: Executes a menu item via its path (e.g., "File/Save Project").
 </details>
 
@@ -172,8 +172,10 @@ If Auto-Configure fails or you use a different client:
 2. **Start your MCP Client** (Claude, Cursor, etc.). It should automatically launch the Unity MCP Server (Python) using the configuration from Installation Step 3.
     
 3. **Interact!** Unity tools should now be available in your MCP Client.
-    
+
     Example Prompt: `Create a 3D player controller.`
+
+    Example Call: `manage_gameobject(action="find", target="Player", include_components=True, include_component_properties=True)`
     
 
 ---

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -117,6 +117,7 @@ Allows creation, modification, searching and deletion of GameObjects in the curr
 public static class ManageGameObject
 ```
 【F:UnityMcpBridge/Editor/Tools/ManageGameObject.cs†L15-L18】
+Optional parameters `include_components` and `include_component_properties` control how much component data is returned when searching for objects or retrieving a scene hierarchy.
 
 ### manage_asset
 Supports importing, creating, modifying and retrieving info about assets and prefabs.
@@ -159,6 +160,7 @@ Once the Unity package is installed and the Python server is configured in Curso
 - `manage_gameobject(action="create", name="Player")` – creates a new GameObject named *Player*.
 - `manage_scene(action="get_hierarchy", path="Assets/Scenes/Main.unity")` – returns a structured description of a scene.
 - `execute_menu_item(menu_path="File/Save Project")` – triggers the Save Project command in the editor.
+- `manage_gameobject(action="find", target="Player", include_components=True, include_component_properties=True)` – find an object and include its components and their properties.
 
 Because the server is implemented using the FastMCP framework, these calls appear to Cursor as standard function-like tools with documentation, arguments and return values. This allows automation of complex Unity workflows from within the editor.
 


### PR DESCRIPTION
## Summary
- document `include_components` and `include_component_properties`
- show example usage of both options

## Testing
- `python -m unittest`