### PR TITLE
Add configurable port option

### DIFF
--- a/UnityMcpBridge/Editor/UnityMcpBridge.cs
+++ b/UnityMcpBridge/Editor/UnityMcpBridge.cs
@@ -11,6 +11,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityMcpBridge.Editor.Helpers;
 using UnityMcpBridge.Editor.Models;
+using UnityMcpBridge.Editor.Data;
 using UnityMcpBridge.Editor.Tools;
 
 namespace UnityMcpBridge.Editor
@@ -25,7 +26,18 @@ namespace UnityMcpBridge.Editor
             string,
             (string commandJson, TaskCompletionSource<string> tcs)
         > commandQueue = new();
-        private static readonly int unityPort = 6400; // Hardcoded port
+
+        private static readonly DefaultServerConfig config = new();
+
+        /// <summary>
+        ///     Port that the bridge listens on for incoming connections.
+        ///     Exposed so the editor window can modify it before starting.
+        /// </summary>
+        public static int UnityPort
+        {
+            get => config.unityPort;
+            set => config.unityPort = value;
+        }
 
         public static bool IsRunning => isRunning;
 
@@ -83,11 +95,11 @@ namespace UnityMcpBridge.Editor
 
             try
             {
-                listener = new TcpListener(IPAddress.Loopback, unityPort);
+                listener = new TcpListener(IPAddress.Loopback, UnityPort);
                 listener.Start();
                 isRunning = true;
                 string serverVersion = ServerInstaller.GetInstalledVersion();
-                Debug.Log($"UnityMcpBridge started on port {unityPort} (Server v{serverVersion}).");
+                Debug.Log($"UnityMcpBridge started on port {UnityPort} (Server v{serverVersion}).");
                 // Assuming ListenerLoop and ProcessCommands are defined elsewhere
                 Task.Run(ListenerLoop);
                 EditorApplication.update += ProcessCommands;
@@ -97,7 +109,7 @@ namespace UnityMcpBridge.Editor
                 if (ex.SocketErrorCode == SocketError.AddressAlreadyInUse)
                 {
                     Debug.LogError(
-                        $"Port {unityPort} is already in use. Ensure no other instances are running or change the port."
+                        $"Port {UnityPort} is already in use. Ensure no other instances are running or change the port."
                     );
                 }
                 else

--- a/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
+++ b/UnityMcpBridge/Editor/Windows/UnityMcpEditorWindow.cs
@@ -16,7 +16,7 @@ namespace UnityMcpBridge.Editor.Windows
         private Vector2 scrollPosition;
         private string pythonServerInstallationStatus = "Not Installed";
         private Color pythonServerInstallationStatusColor = Color.red;
-        private const int unityPort = 6400; // Hardcoded Unity port
+        private int unityPort;
         private const int mcpPort = 6500; // Hardcoded MCP port
         private readonly McpClients mcpClients = new();
 
@@ -31,6 +31,7 @@ namespace UnityMcpBridge.Editor.Windows
             UpdatePythonServerInstallationStatus();
 
             isUnityBridgeRunning = UnityMcpBridge.IsRunning;
+            unityPort = UnityMcpBridge.UnityPort;
             foreach (McpClient mcpClient in mcpClients.clients)
             {
                 CheckMcpConfiguration(mcpClient);
@@ -243,7 +244,7 @@ namespace UnityMcpBridge.Editor.Windows
             EditorGUILayout.BeginVertical(EditorStyles.helpBox);
             EditorGUILayout.LabelField("Unity MCP Bridge", EditorStyles.boldLabel);
             EditorGUILayout.LabelField($"Status: {(isUnityBridgeRunning ? "Running" : "Stopped")}");
-            EditorGUILayout.LabelField($"Port: {unityPort}");
+            unityPort = EditorGUILayout.IntField("Port", unityPort);
 
             if (GUILayout.Button(isUnityBridgeRunning ? "Stop Bridge" : "Start Bridge"))
             {
@@ -268,6 +269,7 @@ namespace UnityMcpBridge.Editor.Windows
             }
             else
             {
+                UnityMcpBridge.UnityPort = unityPort;
                 UnityMcpBridge.Start();
             }
 

--- a/UnityMcpServer/src/config.py
+++ b/UnityMcpServer/src/config.py
@@ -4,6 +4,9 @@ This file contains all configurable parameters for the server.
 """
 
 from dataclasses import dataclass
+import json
+import os
+import logging
 
 @dataclass
 class ServerConfig:
@@ -27,4 +30,37 @@ class ServerConfig:
     retry_delay: float = 1.0
 
 # Create a global config instance
-config = ServerConfig() 
+config = ServerConfig()
+
+
+def _load_config_from_file(path: str) -> None:
+    """Load configuration overrides from a JSON file."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict) and "unity_port" in data:
+            config.unity_port = int(data["unity_port"])
+    except Exception as e:
+        logging.warning(f"Failed to load config file {path}: {e}")
+
+
+def _apply_environment_overrides() -> None:
+    """Override configuration from environment variables if present."""
+    env_port = os.getenv("UNITY_MCP_PORT")
+    if env_port:
+        try:
+            config.unity_port = int(env_port)
+            return
+        except ValueError:
+            logging.warning(f"Invalid UNITY_MCP_PORT value: {env_port}")
+
+    config_path = os.getenv("UNITY_MCP_CONFIG")
+    if config_path and os.path.exists(config_path):
+        _load_config_from_file(config_path)
+    else:
+        default_path = os.path.join(os.path.dirname(__file__), "config.json")
+        if os.path.exists(default_path):
+            _load_config_from_file(default_path)
+
+
+_apply_environment_overrides()

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -6,7 +6,7 @@ This document explains the architecture and workflow of the Unity MCP project an
 
 Unity MCP has two main components:
 
-1. **UnityMcpBridge** – a Unity package running inside the Editor. It listens on TCP port `6400`, receives JSON commands, performs the requested operations in the editor and sends the results back.
+1. **UnityMcpBridge** – a Unity package running inside the Editor. It listens on a TCP port (default `6400`) that can be changed via the `UNITY_MCP_PORT` environment variable or a configuration file. It receives JSON commands, performs the requested operations in the editor and sends the results back.
 2. **UnityMcpServer** – a Python server that exposes MCP tools. It communicates with the UnityMcpBridge via sockets and allows MCP clients (like Cursor) to call Unity operations as functions.
 
 The usual data flow is:


### PR DESCRIPTION
## Summary
- allow UnityMcpBridge port to be configured
- surface port field in UnityMcpEditorWindow
- load UNITY_MCP_PORT in Python server
- document new port configuration

## Testing
- `python3 -m py_compile UnityMcpServer/src/config.py`
