### PR TITLE
Handle port via UNITY_MCP_PORT

### DIFF
--- a/UnityMcpBridge/Editor/UnityMcpBridge.cs
+++ b/UnityMcpBridge/Editor/UnityMcpBridge.cs
@@ -62,6 +62,12 @@ namespace UnityMcpBridge.Editor
 
         static UnityMcpBridge()
         {
+            string envPort = Environment.GetEnvironmentVariable("UNITY_MCP_PORT");
+            if (!string.IsNullOrEmpty(envPort) && int.TryParse(envPort, out int parsed))
+            {
+                UnityPort = parsed;
+            }
+
             Start();
             EditorApplication.quitting += Stop;
         }


### PR DESCRIPTION
## Summary
- allow UnityMcpBridge to read port from `UNITY_MCP_PORT`

## Testing
- `python -m py_compile $(git ls-files '*.py')`