### PR TITLE
Fix domain reload event hookup

### DIFF
--- a/UnityMcpBridge/Editor/UnityMcpBridge.cs
+++ b/UnityMcpBridge/Editor/UnityMcpBridge.cs
@@ -75,11 +75,13 @@ namespace UnityMcpBridge.Editor
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void InitOnSubsystemRegistration()
         {
-            // Stop the previous domain's instance so the port is freed before
-            // the new domain initializes via the static constructor.
+            // Unsubscribe from the editor quitting event from the *previous* domain instance.
+            EditorApplication.quitting -= Stop;
+
+            // Stop any running instance from the previous domain load.
             Stop();
 
-            // Reset static collections for a clean state in the new domain.
+            // Reset other static state.
             commandQueue = new();
 
             // Do not call Start() here. The static constructor marked with


### PR DESCRIPTION
## Summary
- unsubscribe UnityMcpBridge from `EditorApplication.quitting` during domain reload to avoid warning UDR0003

## Testing
- `python -m py_compile UnityMcpServer/src/*.py UnityMcpServer/src/tools/*.py`