### PR TITLE
Fix static event subscription in ExecuteMenuItem

### DIFF
--- a/UnityMcpBridge/Editor/Tools/ExecuteMenuItem.cs
+++ b/UnityMcpBridge/Editor/Tools/ExecuteMenuItem.cs
@@ -93,7 +93,8 @@ namespace UnityMcpBridge.Editor.Tools
             try
             {
                 // Attempt to execute the menu item on the main thread using delayCall for safety.
-                EditorApplication.delayCall += () =>
+                EditorApplication.CallbackFunction callback = null;
+                callback = () =>
                 {
                     try
                     {
@@ -112,7 +113,14 @@ namespace UnityMcpBridge.Editor.Tools
                             $"[ExecuteMenuItem] Exception during delayed execution of '{menuPath}': {delayEx}"
                         );
                     }
+                    finally
+                    {
+                        // Ensure we unsubscribe after execution to avoid lingering callbacks
+                        EditorApplication.delayCall -= callback;
+                    }
                 };
+
+                EditorApplication.delayCall += callback;
 
                 // Report attempt immediately, as execution is delayed.
                 return Response.Success(


### PR DESCRIPTION
## Summary
- prevent lingering delayCall handlers by unsubscribing after execution

## Testing
- `python -m compileall UnityMcpServer/src`