### PR TITLE
Enable socket reuse for Unity bridge

### DIFF
--- a/UnityMcpBridge/Editor/UnityMcpBridge.cs
+++ b/UnityMcpBridge/Editor/UnityMcpBridge.cs
@@ -112,6 +112,15 @@ namespace UnityMcpBridge.Editor
             try
             {
                 listener = new TcpListener(IPAddress.Loopback, UnityPort);
+                // Allow the listener to reuse the address so restarting the
+                // editor doesn't hit "address already in use" when sockets are
+                // in TIME_WAIT.
+                listener.Server.SetSocketOption(
+                    SocketOptionLevel.Socket,
+                    SocketOptionName.ReuseAddress,
+                    true
+                );
+                listener.ExclusiveAddressUse = false;
                 listener.Start();
                 isRunning = true;
                 string serverVersion = ServerInstaller.GetInstalledVersion();

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -66,11 +66,13 @@ The bridge lives in `UnityMcpBridge/Editor`. It launches a TCP listener when the
 
 ```csharp
 listener = new TcpListener(IPAddress.Loopback, unityPort);
+listener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+listener.ExclusiveAddressUse = false;
 listener.Start();
 Task.Run(ListenerLoop);
 EditorApplication.update += ProcessCommands;
 ```
-【F:UnityMcpBridge/Editor/UnityMcpBridge.cs†L132-L142】
+【F:UnityMcpBridge/Editor/UnityMcpBridge.cs†L114-L130】
 
 Each command is routed based on the tool name. For example the `ExecuteCommand` method maps command types to the tool handlers:
 


### PR DESCRIPTION
## Summary
- allow UnityMcpBridge to reuse the TCP port on restart
- document the updated listener setup

## Testing
- `git status --short`
